### PR TITLE
feat: Update CI/CD workflow trigger action and upgrade the gh-pages v…

### DIFF
--- a/.github/workflows/jekyll-docker.yml
+++ b/.github/workflows/jekyll-docker.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
   build:
@@ -31,7 +28,7 @@ jobs:
 
     - name: Deploy to GitHub Pages
       if: github.ref == 'refs/heads/main'
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./_site


### PR DESCRIPTION
…ersion

Now, the workflow will only trigger when changes are pushed to main and not on creation of pull request. Also upgraded the peaceiris/actions-gh-pages to version 4 from version 3. This should suppress the build warning about old node.js version and it will also use the latest version of the repo.