### PR TITLE
feat: Grant write permission for pages and id-token

### DIFF
--- a/.github/workflows/jekyll-docker.yml
+++ b/.github/workflows/jekyll-docker.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  pages: write
+  id-token: write
+
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The read and write permissions are granted to the default GitHub Token for GitHub Pages and and id. These permissions are mandatory for actions/deploy-pages@v4.