### PR TITLE
Redesign hero: full-screen GPU engine with boot + materialize sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,13 @@ Live: **https://nightshade14.github.io/satyamchatrola**
 ## Stack
 
 - **[Astro](https://astro.build)** — static, zero-JS-by-default output (fast under any condition)
-- Self-hosted fonts via `@fontsource-variable` (Space Grotesk · Geist · Geist Mono)
-- Single scrolling page, dark theme with one electric-cyan accent
-- One small client script drives the hero "decode" animation + scroll reveals; everything else is static HTML/CSS
+- Self-hosted fonts via `@fontsource-variable` (Bricolage Grotesque · Geist · Geist Mono)
+- Single scrolling page, "compute night" dark theme with one electric-cyan accent
+- **Full-screen GPU "engine"** ([three.js](https://threejs.org), lazy-loaded): a fixed WebGL backdrop
+  the page boots on — scrolling dollies the camera back and crossfades it to a faint always-running
+  presence. Real `.glb` (Draco/Meshopt) lit by an HDRI studio env; degrades to a particle field
+  if WebGL/the model is unavailable, and holds static under `prefers-reduced-motion`
+- Client scripts drive the boot crossfade, the hero "decode" stream, and scroll reveals; the rest is static HTML/CSS
 - Deployed to **GitHub Pages via GitHub Actions**
 
 ## Develop
@@ -23,9 +27,10 @@ npm run preview  # preview the built site
 
 ## Editing content
 
-All copy and data live in `src/pages/index.astro` (top of the file): the hero response,
-`focus`, `highlights`, `creds`, `projects`, and `links` arrays. Design tokens (colors, type
-scale, spacing) are in `src/styles/global.css`. Static assets (headshot, résumé, research PDF)
+All copy and data live in `src/pages/index.astro` (top of the file): the `RESPONSES` decode pool,
+`stats`, `focus`, `highlights`, `creds`, `projects`, and `links` arrays. Design tokens (colors, type
+scale, spacing) are in `src/styles/global.css`. The 3D engine lives in `src/components/GpuScene.astro`
+(model at `public/models/*.glb`, HDRI at `public/hdri/*.hdr`). Static assets (résumé, research PDF)
 are in `public/`.
 
 ## Deployment

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "satyamchatrola-portfolio",
       "version": "1.0.0",
       "dependencies": {
+        "@fontsource-variable/bricolage-grotesque": "^5.2.10",
         "@fontsource-variable/geist": "^5.2.0",
         "@fontsource-variable/geist-mono": "^5.2.0",
-        "@fontsource-variable/space-grotesk": "^5.2.0",
         "astro": "^7.0.6",
         "three": "^0.180.0"
       }
@@ -939,6 +939,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/@fontsource-variable/bricolage-grotesque": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/bricolage-grotesque/-/bricolage-grotesque-5.2.10.tgz",
+      "integrity": "sha512-5EDsCqgGpKVcJWE4sg9ydli+t5WM97mISYw5lla/Ev4z71FwXh1oN0YUU8xjkRW9+wBCGD9R+ntAvI8G4bUFJg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
     "node_modules/@fontsource-variable/geist": {
       "version": "5.2.9",
       "resolved": "https://registry.npmjs.org/@fontsource-variable/geist/-/geist-5.2.9.tgz",
@@ -952,15 +961,6 @@
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/@fontsource-variable/geist-mono/-/geist-mono-5.2.8.tgz",
       "integrity": "sha512-KI5bj+hkkRiHttYHmccotUZ80ZuZyai+RwI1d7UId0clkx/jXxlo8qYK8j54WzmpBjtMoEMPyllV7faDcj+6RA==",
-      "license": "OFL-1.1",
-      "funding": {
-        "url": "https://github.com/sponsors/ayuhito"
-      }
-    },
-    "node_modules/@fontsource-variable/space-grotesk": {
-      "version": "5.2.10",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/space-grotesk/-/space-grotesk-5.2.10.tgz",
-      "integrity": "sha512-yJQO/o35/hAP3CFnpdFTwQku2yzJOae2HIpBmqkOVoxhhXJaQP3g+b6Jrz7u+eI7A5ZdCIf88uMWpBJdFiGr5w==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "astro": "astro"
   },
   "dependencies": {
+    "@fontsource-variable/bricolage-grotesque": "^5.2.10",
     "@fontsource-variable/geist": "^5.2.0",
     "@fontsource-variable/geist-mono": "^5.2.0",
-    "@fontsource-variable/space-grotesk": "^5.2.0",
     "astro": "^7.0.6",
     "three": "^0.180.0"
   }

--- a/src/components/GpuScene.astro
+++ b/src/components/GpuScene.astro
@@ -1,41 +1,45 @@
 ---
-// Photoreal 3D GPU hero. Loads a real .glb model, lights it with an HDRI
-// studio environment (accurate metal reflections), auto-centers/scales/frames
-// it, and floats it with pointer parallax. Lazy-loaded; falls back to a quiet
-// ambient field if no model is present or WebGL is unavailable.
-//
-// Drop your model at: public/models/gpu.glb   (Draco / Meshopt supported)
+// The engine. A fixed, full-viewport WebGL backdrop that the whole page
+// "boots" on: at load the GPU fills the screen; as you scroll the camera
+// dollies back and the canvas crossfades (via the CSS `--boot` var, set by
+// the page script) to a faint always-running ambient presence behind the
+// content. Real .glb + HDRI studio lighting; lazy-loaded; degrades to a
+// quiet particle field if WebGL or the model is unavailable.
 ---
 
-<div class="gpu-stage" id="gpu-stage" aria-hidden="true" data-reveal style="--reveal-delay: 220ms">
-  <span class="gpu-tag">compute · live</span>
-</div>
+<div id="engine" aria-hidden="true"></div>
 
 <script>
   const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
   const MODEL_URL = `${BASE}/models/geforce_rtx_3080_graphics_card.glb`;
   const HDRI_URL = `${BASE}/hdri/studio.hdr`;
 
-  const stage = document.getElementById('gpu-stage');
+  const stage = document.getElementById('engine');
   if (stage) {
     const kickoff = () => {
       const idle = window.requestIdleCallback || ((fn) => setTimeout(fn, 200));
       idle(() => boot(stage));
     };
-    if ('IntersectionObserver' in window) {
-      const io = new IntersectionObserver((entries) => {
-        if (entries.some((e) => e.isIntersecting)) { io.disconnect(); kickoff(); }
-      }, { rootMargin: '200px' });
-      io.observe(stage);
-    } else {
-      kickoff();
-    }
+    kickoff();
   }
+
+  // Boot progress: 0 = engine full-screen, 1 = site booted. The page script
+  // owns the canonical value on window.__bootP and the CSS `--boot` var.
+  const bootP = () => (typeof window.__bootP === 'number' ? window.__bootP : 0);
 
   let booted = false;
   async function boot(stage) {
     if (booted) return;
     booted = true;
+
+    // Tell the hero the engine has come online (or failed) exactly once, so it
+    // can flip "spinning up…" → "online" and spin up the telemetry in sync.
+    let readySignaled = false;
+    const signalReady = () => {
+      if (readySignaled) return;
+      readySignaled = true;
+      try { window.dispatchEvent(new CustomEvent('engine:ready')); } catch (e) {}
+    };
 
     let THREE, GLTFLoader, DRACOLoader, RGBELoader, MeshoptDecoder;
     let EffectComposer, RenderPass, UnrealBloomPass, OutputPass;
@@ -50,36 +54,40 @@
       ({ UnrealBloomPass } = await import('three/addons/postprocessing/UnrealBloomPass.js'));
       ({ OutputPass } = await import('three/addons/postprocessing/OutputPass.js'));
     } catch (e) {
-      stage.classList.add('gpu-failed');
+      stage.classList.add('engine-failed');
+      signalReady();
       return;
     }
 
     const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     const finePointer = window.matchMedia('(pointer: fine)').matches;
+    const coarse = window.matchMedia('(pointer: coarse)').matches;
 
-    let width = stage.clientWidth || 480;
-    let height = stage.clientHeight || 420;
+    let width = window.innerWidth;
+    let height = window.innerHeight;
 
     let renderer;
     try {
       renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
       if (!renderer.getContext()) throw new Error('no webgl');
     } catch (e) {
-      stage.classList.add('gpu-failed');
+      stage.classList.add('engine-failed');
+      signalReady();
       return;
     }
-    const DPR = Math.min(window.devicePixelRatio || 1, 2);
+    // Full-screen fill rate is the cost driver — cap DPR harder on touch.
+    const DPR = Math.min(window.devicePixelRatio || 1, coarse ? 1.5 : 2);
     renderer.setPixelRatio(DPR);
     renderer.setSize(width, height);
     renderer.setClearColor(0x000000, 0);
     renderer.toneMapping = THREE.ACESFilmicToneMapping;
-    renderer.toneMappingExposure = 0.95;
-    renderer.domElement.classList.add('gpu-canvas');
+    renderer.toneMappingExposure = 0.98;
+    renderer.domElement.classList.add('engine-canvas');
     stage.appendChild(renderer.domElement);
 
     const scene = new THREE.Scene();
     const camera = new THREE.PerspectiveCamera(32, width / height, 0.1, 100);
-    camera.position.set(0, 0, 9);
+    camera.position.set(0, 0.2, 9);
     camera.lookAt(0, 0, 0);
 
     // ---------- HDRI environment (accurate reflections on metal) ----------
@@ -91,27 +99,30 @@
       hdr.dispose();
     });
 
-    // a soft key light + cool rim/underglow (the glow accent) so the card reads
-    const key = new THREE.DirectionalLight(0xffffff, 1.3);
+    // soft key + cool rim + a cyan underglow (the accent), so the card reads
+    const key = new THREE.DirectionalLight(0xffffff, 1.35);
     key.position.set(4, 6, 6);
     scene.add(key);
-    const rim = new THREE.DirectionalLight(0x8fb6ff, 0.7);
+    const rim = new THREE.DirectionalLight(0x8fb6ff, 0.75);
     rim.position.set(-6, -1, -4);
     scene.add(rim);
-    const cyanGlow = new THREE.PointLight(0x22d3ee, 14, 24);
-    cyanGlow.position.set(-2.4, -2.4, 2.4);
+    const cyanGlow = new THREE.PointLight(0x22d3ee, 16, 26);
+    cyanGlow.position.set(-2.4, -2.2, 2.6);
     scene.add(cyanGlow);
+    const ionGlow = new THREE.PointLight(0x2f6bff, 9, 24);
+    ionGlow.position.set(3.0, 1.8, 1.5);
+    scene.add(ionGlow);
 
-    // group that floats / tilts
+    // group that floats / dollies / tilts
     const rig = new THREE.Group();
     scene.add(rig);
 
-    // ---------- soft bloom for the glow (subtle, only the brightest bits) ----------
+    // ---------- bloom for the glow (ramps down as the site boots) ----------
     const composer = new EffectComposer(renderer);
     composer.setPixelRatio(DPR);
     composer.setSize(width, height);
     composer.addPass(new RenderPass(scene, camera));
-    const bloom = new UnrealBloomPass(new THREE.Vector2(width, height), 0.28, 0.6, 0.8);
+    const bloom = new UnrealBloomPass(new THREE.Vector2(width, height), 0.34, 0.7, 0.82);
     composer.addPass(bloom);
     composer.addPass(new OutputPass());
 
@@ -125,6 +136,24 @@
     let model = null;
     let mixer = null;
     let fanCenters = [];
+    let sizeX = 5.5, sizeY = 3, baseZ = 9;
+    // materialize intro: rig eases up + a gentle bloom "power surge" that decays
+    const INTRO = 2.6; // seconds — slow, smooth phase-in
+    let introT = null, introBloom = 0;
+    const startIntro = () => {
+      if (prefersReduced) return;
+      rig.scale.setScalar(0.92);
+      introT = clock.elapsedTime;
+    };
+
+    // Frame the model to fill the viewport with a small margin; re-fit on resize.
+    function refit() {
+      const halfV = THREE.MathUtils.degToRad(camera.fov) / 2;
+      const dH = (sizeY / 2) / Math.tan(halfV);
+      const halfH = Math.atan(Math.tan(halfV) * camera.aspect);
+      const dW = (sizeX / 2) / Math.tan(halfH);
+      baseZ = Math.max(dH, dW) * 1.14;
+    }
 
     loader.load(
       MODEL_URL,
@@ -132,8 +161,6 @@
         model = gltf.scene;
 
         // ---- auto-orient with proper rotations only (no mirroring) ----
-        // 1) fan face (thinnest axis) → camera (+Z); 2) roll so length lies horizontal.
-        // FACE_FLIP shows the other broad face if the backplate ends up toward us.
         const FACE_FLIP = true;
         model.updateMatrixWorld(true);
         let box = new THREE.Box3().setFromObject(model);
@@ -145,20 +172,25 @@
 
         const faceAxis = axisVec(smallest, FACE_FLIP ? -1 : 1);
         const q1 = new THREE.Quaternion().setFromUnitVectors(faceAxis, new THREE.Vector3(0, 0, 1));
-        const lenAfter = axisVec(longest, 1).applyQuaternion(q1); // now lies ~in the XY plane
-        const roll = -Math.atan2(lenAfter.y, lenAfter.x);         // bring length onto +X (level)
+        const lenAfter = axisVec(longest, 1).applyQuaternion(q1);
+        const roll = -Math.atan2(lenAfter.y, lenAfter.x);
         const q2 = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 0, 1), roll);
         model.quaternion.copy(q1).premultiply(q2);
 
-        // scale to a consistent on-screen size, then re-center (after rotation)
+        // scale to a consistent world size, then re-center (after rotation)
         const maxDim = Math.max(size.x, size.y, size.z) || 1;
-        const target = 5.9;
+        const target = 5.6;
         model.scale.setScalar(target / maxDim);
         model.updateMatrixWorld(true);
         box = new THREE.Box3().setFromObject(model);
         model.position.sub(box.getCenter(new THREE.Vector3()));
 
-        // HDRI drives the metal; a gentle emissive lift so branding reads (not blown out)
+        // remember the framed footprint so refit() keeps it in view
+        model.updateMatrixWorld(true);
+        const fsize = new THREE.Box3().setFromObject(model).getSize(new THREE.Vector3());
+        sizeX = fsize.x; sizeY = fsize.y;
+        refit();
+
         model.traverse((o) => {
           if (o.isMesh && o.material) {
             const mats = Array.isArray(o.material) ? o.material : [o.material];
@@ -172,18 +204,17 @@
 
         rig.add(model);
 
-        // spin the fans via the model's own animation clip (armature-driven)
+        // spin the fans via the model's own armature clip
         if (gltf.animations && gltf.animations.length && !prefersReduced) {
           mixer = new THREE.AnimationMixer(model);
           const clip = gltf.animations.find((c) => /1200/.test(c.name))
             || gltf.animations.find((c) => /rpm/.test(c.name)) || gltf.animations[0];
           const action = mixer.clipAction(clip);
-          action.timeScale = 0.55; // ease the spin so it reads smoothly, not strobing
+          action.timeScale = 0.55;
           action.play();
-          stage.dataset.fanclip = clip.name;
         }
 
-        // locate the fan centres (rig-local) so airflow converges on them
+        // fan centres (rig-local) so intake airflow converges on them
         scene.updateMatrixWorld(true);
         const nodes = [];
         model.traverse((o) => { if (o.name === 'fan' || o.name === 'fan_2') nodes.push(o); });
@@ -194,19 +225,22 @@
         });
         buildAirflow();
 
-        stage.classList.add('gpu-live');
+        stage.classList.add('engine-live');
+        signalReady();
+        if (prefersReduced) settle(); else startIntro();
       },
       undefined,
       () => {
-        // no model → keep the quiet ambient fallback field
         buildFallback();
-        stage.classList.add('gpu-live', 'gpu-nomodel');
+        stage.classList.add('engine-live', 'engine-nomodel');
+        signalReady();
+        if (prefersReduced) settle(); else startIntro();
       },
     );
 
     // ---------- subtle intake airflow converging on the fan centres ----------
     let airflow = null, aPos = null, aFan = null, aSpd = null;
-    const AN = 300;
+    const AN = 280;
     function makeSprite(inner) {
       const c = document.createElement('canvas'); c.width = c.height = 64;
       const g = c.getContext('2d');
@@ -221,7 +255,6 @@
       aFan[i] = f;
       const c = fanCenters[f];
       const r = (near ? 0.2 : 0.8) + Math.random() * 1.4;
-      // random point on a sphere shell around the fan centre
       const th = Math.random() * Math.PI * 2, ph = Math.acos(2 * Math.random() - 1);
       aPos[i * 3] = c.x + r * Math.sin(ph) * Math.cos(th);
       aPos[i * 3 + 1] = c.y + r * Math.sin(ph) * Math.sin(th);
@@ -235,39 +268,33 @@
       const g = new THREE.BufferGeometry();
       g.setAttribute('position', new THREE.BufferAttribute(aPos, 3));
       airflow = new THREE.Points(g, new THREE.PointsMaterial({
-        size: 0.06, map: makeSprite('rgba(190,235,255,0.9)'), transparent: true,
-        depthWrite: false, blending: THREE.AdditiveBlending, opacity: 0.4,
+        size: 0.055, map: makeSprite('rgba(190,235,255,0.9)'), transparent: true,
+        depthWrite: false, blending: THREE.AdditiveBlending, opacity: 0.36,
       }));
       rig.add(airflow);
     }
 
-    // ---------- fallback ambient field (only if the model is missing) ----------
+    // ---------- fallback ambient field (model missing / decode failed) ----------
     let points = null;
     function buildFallback() {
-      const N = 320;
+      const N = 340;
       const pos = new Float32Array(N * 3);
       for (let i = 0; i < N; i++) {
-        pos[i * 3] = (Math.random() - 0.5) * 7;
-        pos[i * 3 + 1] = (Math.random() - 0.5) * 5;
-        pos[i * 3 + 2] = (Math.random() - 0.5) * 5;
+        pos[i * 3] = (Math.random() - 0.5) * 8;
+        pos[i * 3 + 1] = (Math.random() - 0.5) * 5.5;
+        pos[i * 3 + 2] = (Math.random() - 0.5) * 5.5;
       }
       const g = new THREE.BufferGeometry();
       g.setAttribute('position', new THREE.BufferAttribute(pos, 3));
-      const sc = document.createElement('canvas'); sc.width = sc.height = 64;
-      const sg = sc.getContext('2d');
-      const grad = sg.createRadialGradient(32, 32, 0, 32, 32, 32);
-      grad.addColorStop(0, 'rgba(190,235,255,0.9)');
-      grad.addColorStop(1, 'rgba(80,150,255,0)');
-      sg.fillStyle = grad; sg.fillRect(0, 0, 64, 64);
       points = new THREE.Points(g, new THREE.PointsMaterial({
-        size: 0.08, map: new THREE.CanvasTexture(sc), transparent: true,
+        size: 0.08, map: makeSprite('rgba(190,235,255,0.9)'), transparent: true,
         depthWrite: false, blending: THREE.AdditiveBlending, opacity: 0.5,
       }));
       rig.add(points);
     }
 
     // ---------- base orientation + interaction ----------
-    const ROT_Y = -0.5, ROT_X = 0.12;
+    const ROT_Y = -0.42, ROT_X = 0.1;
     rig.rotation.set(ROT_X, ROT_Y, 0);
 
     let pointerX = 0, pointerY = 0;
@@ -279,24 +306,46 @@
     }
 
     const onResize = () => {
-      width = stage.clientWidth || width;
-      height = stage.clientHeight || height;
+      width = window.innerWidth;
+      height = window.innerHeight;
       camera.aspect = width / height;
       camera.updateProjectionMatrix();
       renderer.setSize(width, height);
+      composer.setSize(width, height);
+      refit();
+      if (prefersReduced) settle();
     };
     window.addEventListener('resize', onResize, { passive: true });
 
     const clock = new THREE.Clock();
     let running = true;
+    let frameNo = 0;
+
+    // Render one frame at the current boot/camera state (no animation stepping).
+    function drawOnce() {
+      const p = bootP();
+      camera.position.z = baseZ + p * baseZ * 0.7;
+      camera.position.y = 0.2 + p * 0.6;
+      camera.lookAt(0, 0, 0);
+      bloom.strength = 0.34 - p * 0.22;
+      composer.render();
+    }
+
+    // For reduced motion / static: render a handful of frames so a late model
+    // or environment map still shows, then hold.
+    function settle() {
+      let n = 0;
+      const step = () => { drawOnce(); if (n++ < 90) requestAnimationFrame(step); };
+      step();
+    }
 
     function frame() {
+      const p = bootP();
       const t = clock.elapsedTime;
       const dt = Math.min(clock.getDelta(), 0.05);
 
-      if (mixer) mixer.update(dt); // spin the fans
+      if (mixer) mixer.update(dt);
 
-      // subtle intake: motes converge on the fan centres, respawn on contact
       if (airflow) {
         for (let i = 0; i < AN; i++) {
           const ix = i * 3;
@@ -312,11 +361,30 @@
         airflow.geometry.attributes.position.needsUpdate = true;
       }
 
-      // gentle float + sway + pointer parallax
+      // materialize intro: scale the rig up out of the core + surge the bloom
+      if (introT !== null) {
+        const ri = Math.min((t - introT) / INTRO, 1);
+        // ease-in-out: gentle at both ends so nothing snaps
+        const e = ri < 0.5 ? 4 * ri * ri * ri : 1 - Math.pow(-2 * ri + 2, 3) / 2;
+        rig.scale.setScalar(0.92 + 0.08 * e);
+        introBloom = (1 - e) * 0.32;
+        if (airflow) airflow.material.opacity = 0.36 * e;
+        if (points) points.material.opacity = 0.5 * e;
+        if (ri >= 1) { introT = null; introBloom = 0; rig.scale.setScalar(1); }
+      }
+
+      // camera dolly (boot) + a whisper of idle drift
+      camera.position.z = baseZ + p * baseZ * 0.7 + Math.sin(t * 0.25) * 0.05;
+      camera.position.y = 0.2 + p * 0.6;
+      camera.lookAt(0, 0, 0);
+      bloom.strength = (0.34 - p * 0.22) + introBloom;
+
+      // gentle float + sway + pointer parallax (eased out as the site boots)
+      const parallax = 1 - p * 0.7;
       rig.position.y = Math.sin(t * 0.7) * 0.14;
       rig.position.x = Math.sin(t * 0.45) * 0.05;
-      const targetY = ROT_Y + pointerX * 0.55 + Math.sin(t * 0.2) * 0.05;
-      const targetX = ROT_X + pointerY * 0.3;
+      const targetY = ROT_Y + (pointerX * 0.5 + Math.sin(t * 0.2) * 0.05) * parallax;
+      const targetX = ROT_X + (pointerY * 0.28) * parallax;
       rig.rotation.y += (targetY - rig.rotation.y) * 0.06;
       rig.rotation.x += (targetX - rig.rotation.x) * 0.06;
       rig.rotation.z = Math.sin(t * 0.5) * 0.012;
@@ -326,22 +394,21 @@
       composer.render();
     }
 
-    function loop() { if (!running) return; frame(); requestAnimationFrame(loop); }
+    function loop() {
+      if (!running) return;
+      requestAnimationFrame(loop);
+      frameNo++;
+      // Once mostly booted the engine is just ambient — halve its frame rate.
+      if (bootP() >= 0.9 && (frameNo & 1)) return;
+      frame();
+    }
 
     if (prefersReduced) {
-      // render a few frames so late-loading model/env still show, then hold
-      let n = 0;
-      const settle = () => { composer.render(); if (n++ < 90) requestAnimationFrame(settle); };
+      // static: opacity crossfade (CSS `--boot`) carries the transition
       settle();
     } else {
-      const vis = new IntersectionObserver((entries) => {
-        const on = entries.some((e) => e.isIntersecting);
-        if (on && !running) { running = true; clock.getDelta(); loop(); }
-        if (!on) running = false;
-      }, { threshold: 0.01 });
-      vis.observe(stage);
       document.addEventListener('visibilitychange', () => {
-        if (document.hidden) running = false;
+        if (document.hidden) { running = false; }
         else if (!running) { running = true; clock.getDelta(); loop(); }
       });
       loop();
@@ -350,43 +417,46 @@
 </script>
 
 <style>
-  .gpu-stage {
-    position: relative;
-    width: 100%;
-    min-height: 420px;
-    aspect-ratio: 4 / 3;
-    max-height: 520px;
-    background:
-      radial-gradient(58% 52% at 52% 46%, rgba(34, 211, 238, 0.08), transparent 70%),
-      radial-gradient(45% 45% at 50% 62%, rgba(47, 107, 255, 0.06), transparent 72%);
+  #engine {
+    position: fixed;
+    inset: 0;
+    z-index: 0;
+    pointer-events: none;
+    /* crossfade to a faint always-running presence as the site boots
+       (no transition here — must track scroll instantly) */
+    opacity: calc(1 - var(--boot) * 0.82);
   }
-  .gpu-canvas { position: absolute; inset: 0; width: 100% !important; height: 100% !important; }
-  .gpu-tag {
-    position: absolute;
-    left: 0; bottom: 6px;
-    z-index: 2;
-    font-family: var(--font-mono);
-    font-size: var(--step--1);
-    color: var(--text-faint);
-    letter-spacing: 0.06em;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5em;
-    opacity: 0;
-    transition: opacity 0.6s ease 0.3s;
-  }
-  .gpu-tag::before {
+  /* the "core": a cyan glow that breathes while the engine spins up, so the
+     load pause reads as powering-on. Settles once the engine is live. */
+  #engine::before {
     content: "";
-    width: 6px; height: 6px; border-radius: 50%;
-    background: var(--accent);
-    box-shadow: 0 0 10px var(--accent-glow);
-    animation: gpu-pulse 1.6s ease-in-out infinite;
+    position: absolute;
+    inset: 0;
+    transform-origin: center;
+    background:
+      radial-gradient(60% 55% at 50% 46%, rgba(34, 211, 238, 0.11), transparent 70%),
+      radial-gradient(50% 50% at 50% 64%, rgba(47, 107, 255, 0.08), transparent 72%);
+    animation: engine-charge 2.6s ease-in-out infinite;
   }
-  .gpu-live .gpu-tag { opacity: 1; }
-  @keyframes gpu-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
-  .gpu-failed { display: none; }
-  @media (prefers-reduced-motion: reduce) { .gpu-tag::before { animation: none; } }
-  @media (max-width: 900px) {
-    .gpu-stage { min-height: 320px; max-height: 380px; aspect-ratio: 16 / 11; }
+  @keyframes engine-charge {
+    0%, 100% { opacity: 0.45; transform: scale(0.955); }
+    50%      { opacity: 1;    transform: scale(1.035); }
+  }
+  #engine.engine-live::before { animation: none; opacity: 0.85; transition: opacity 1s ease; }
+
+  /* the rendered GPU fades in over the core as it becomes ready — slow + smooth */
+  .engine-canvas {
+    position: absolute; inset: 0;
+    width: 100% !important; height: 100% !important;
+    opacity: 0;
+    transition: opacity 2.2s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+  #engine.engine-live .engine-canvas { opacity: 1; }
+
+  .engine-failed { display: none; }
+  @media (prefers-reduced-motion: reduce) {
+    /* keep a readable minimum so the static card never fully vanishes */
+    #engine { opacity: calc(1 - var(--boot) * 0.7); }
+    #engine::before { animation: none; opacity: 0.8; }
   }
 </style>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,5 +1,5 @@
 ---
-import '@fontsource-variable/space-grotesk';
+import '@fontsource-variable/bricolage-grotesque';
 import '@fontsource-variable/geist';
 import '@fontsource-variable/geist-mono';
 import '../styles/global.css';
@@ -41,7 +41,9 @@ const ogImage = new URL(`${import.meta.env.BASE_URL}/images/satyam_headshot.png`
 
     <!-- If JS is off, the IntersectionObserver reveal never runs — show everything. -->
     <noscript>
-      <style>[data-reveal] { opacity: 1 !important; transform: none !important; }</style>
+      <style>
+        [data-reveal], [data-hero] { opacity: 1 !important; transform: none !important; }
+      </style>
     </noscript>
   </head>
   <body>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,7 +8,7 @@ const PAPER_PDF = `${base}/pdf/satyam-chatrola-research-paper.pdf`;
 const PAPER_URL =
   'https://www.researchgate.net/publication/388835538_Benchmarking_Fine-Tuned_Transformers_LLMs_and_LSTM_Networks_for_Automated_Essay_Scoring';
 
-// The hero "response" — streamed token by token like a model decoding.
+// The "response" — streamed token by token like a model decoding.
 // Clicking "resample" re-runs the decode with another line from this pool.
 const RESPONSES = [
   'AI Systems Engineer. I build low-latency systems that serve large language models — from inference optimization and serving infrastructure to ML at planet scale.',
@@ -128,6 +128,9 @@ const links = [
   title="Satyam Chatrola — AI Systems Engineer · LLM inference & serving"
   description="Satyam Chatrola is an AI Systems Engineer specializing in LLM inference and serving — low-latency model serving, inference optimization, and ML systems at scale."
 >
+  <!-- The engine: a fixed full-viewport GPU the whole page boots on. -->
+  <GpuScene />
+
   <!-- ================= NAV ================= -->
   <header class="nav">
     <div class="shell nav-inner">
@@ -143,23 +146,50 @@ const links = [
     </div>
   </header>
 
-  <div class="spotlight" aria-hidden="true"></div>
-
   <main id="top">
-    <!-- ================= HERO ================= -->
-    <section class="hero shell">
-      <div class="hero-copy">
-        <p class="prompt" data-reveal><span class="prompt-caret">&gt;</span> whoami</p>
+    <!-- ================= HERO (overlay on the engine) ================= -->
+    <section class="stage">
+      <div class="shell stage-inner">
+        <p class="eyebrow eyebrow-live" data-hero>inference engine — online</p>
 
-        <h1 class="hero-name" data-reveal style="--reveal-delay: 90ms">
+        <h1 class="hero-name" data-hero style="--reveal-delay: 90ms">
           Satyam<br />Chatrola
         </h1>
 
-        <p class="hero-response" data-reveal style="--reveal-delay: 180ms">
+        <p class="hero-role" data-hero style="--reveal-delay: 180ms">
+          AI&nbsp;Systems&nbsp;Engineer <span class="role-sep">·</span> LLM&nbsp;inference&nbsp;&amp;&nbsp;serving
+        </p>
+
+        <p class="hero-readout" data-hero style="--reveal-delay: 250ms" aria-hidden="true">
+          <span class="ro-dot"></span>online
+          <span class="ro-sep">·</span> <span id="ro-tps">—</span>&nbsp;tok/s
+          <span class="ro-sep">·</span> TTFT&nbsp;<span id="ro-ttft">—</span>
+          <span class="ro-sep">·</span> util&nbsp;<span id="ro-util">—</span>%
+        </p>
+
+        <div class="hero-cta" data-hero style="--reveal-delay: 330ms">
+          <a class="btn btn-primary" data-magnetic href="#work">View work</a>
+          <a class="btn" data-magnetic href={RESUME} target="_blank" rel="noopener">Download résumé <span aria-hidden="true">↗</span></a>
+        </div>
+      </div>
+
+      <a class="scroll-cue" href="#response" aria-label="Scroll to enter">
+        <span class="cue-label">scroll to boot</span>
+        <span class="cue-arrow" aria-hidden="true">↓</span>
+      </a>
+    </section>
+
+    <div class="deck">
+      <!-- ================= RESPONSE (the decode signature) ================= -->
+      <section id="response" class="section shell">
+        <p class="eyebrow" data-reveal>response</p>
+        <p class="prompt" data-reveal style="--reveal-delay: 70ms"><span class="prompt-caret">&gt;</span> whoami</p>
+
+        <p class="decode-line" data-reveal style="--reveal-delay: 140ms">
           <span id="decode" data-full={RESPONSE} aria-label={RESPONSE}></span><span class="cursor" id="cursor" aria-hidden="true"></span>
         </p>
 
-        <div class="hero-meta" data-reveal style="--reveal-delay: 260ms">
+        <div class="decode-meta" data-reveal style="--reveal-delay: 220ms">
           <div class="telemetry" aria-hidden="true">
             <span class="tel-item"><span id="tokcount">0</span> tokens</span>
             <span class="tel-sep">·</span>
@@ -171,151 +201,205 @@ const links = [
             <span class="regen-ico" aria-hidden="true">↻</span> resample
           </button>
         </div>
+      </section>
 
-        <div class="hero-cta" data-reveal style="--reveal-delay: 340ms">
-          <a class="btn btn-primary" data-magnetic href="#work">View work</a>
-          <a class="btn" data-magnetic href={RESUME} target="_blank" rel="noopener">Download résumé <span aria-hidden="true">↗</span></a>
+      <!-- ================= FOCUS ================= -->
+      <section id="focus" class="section shell">
+        <p class="eyebrow" data-reveal>focus</p>
+        <h2 class="section-title" data-reveal>What I do</h2>
+        <div class="focus-grid">
+          {focus.map((f, i) => (
+            <article class="focus-card" data-reveal style={`--reveal-delay: ${i * 70}ms`}>
+              <span class="focus-k">{f.k}</span>
+              <h3>{f.title}</h3>
+              <p>{f.body}</p>
+            </article>
+          ))}
         </div>
-      </div>
+      </section>
 
-      <div class="hero-visual">
-        <GpuScene />
-      </div>
-    </section>
-
-    <!-- ================= FOCUS ================= -->
-    <section id="focus" class="section shell">
-      <p class="eyebrow" data-reveal>focus</p>
-      <h2 class="section-title" data-reveal>What I do</h2>
-      <div class="focus-grid">
-        {focus.map((f, i) => (
-          <article class="focus-card" data-reveal style={`--reveal-delay: ${i * 70}ms`}>
-            <span class="focus-k">{f.k}</span>
-            <h3>{f.title}</h3>
-            <p>{f.body}</p>
-          </article>
-        ))}
-      </div>
-    </section>
-
-    <!-- ================= EXPERIENCE ================= -->
-    <section id="experience" class="section shell">
-      <p class="eyebrow" data-reveal>signal</p>
-      <div class="exp">
-        <div class="exp-lead">
-          <h2 class="section-title" data-reveal>
-            I turn models into<br /><span class="accent-text">fast, dependable endpoints.</span>
-          </h2>
-          <div class="stats" data-reveal style="--reveal-delay: 140ms">
-            {stats.map((s) => (
-              <div class="stat">
-                <span
-                  class="stat-num"
-                  data-count={s.value}
-                  data-decimals={s.decimals}
-                  data-prefix={s.prefix}
-                  data-suffix={s.suffix}
-                >{s.prefix}0{s.suffix}</span>
-                <span class="stat-label">{s.label}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-        <div class="exp-body" data-reveal style="--reveal-delay: 90ms">
-          <p>
-            I'm an AI Systems Engineer and MS Computer Science student at NYU, focused on the part of
-            machine learning that decides whether it's actually useful: <strong>how it's served.</strong>{' '}
-            My work sits where software engineering, systems, and ML meet — making inference fast, cheap,
-            and reliable at scale.
-          </p>
-          <ul class="exp-list">
-            {highlights.map((h) => <li>{h}</li>)}
-          </ul>
-          <div class="creds">
-            {creds.map((c) => <span class="cred">{c}</span>)}
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- ================= WORK ================= -->
-    <section id="work" class="section shell">
-      <p class="eyebrow" data-reveal>work</p>
-      <h2 class="section-title" data-reveal>Selected projects</h2>
-      <div class="work-grid">
-        {projects.map((p, i) => (
-          <a class="work-card" data-tilt href={p.url} target="_blank" rel="noopener" data-reveal style={`--reveal-delay: ${i * 55}ms`}>
-            <span class="work-glare" aria-hidden="true"></span>
-            <div class="work-inner">
-              <div class="work-top">
-                <span class="work-tag">{p.tag}</span>
-                <span class="work-open" aria-hidden="true">→</span>
-              </div>
-              <h3 class="work-name">{p.name}</h3>
-              <p class="work-desc">{p.desc}</p>
-              <div class="work-meta">
-                <span class="work-lang"><span class="lang-dot"></span>{p.lang}</span>
-                {p.star > 0 && <span class="work-star">★ {p.star}</span>}
-              </div>
+      <!-- ================= SIGNAL / EXPERIENCE ================= -->
+      <section id="signal" class="section shell">
+        <p class="eyebrow" data-reveal>signal</p>
+        <div class="exp">
+          <div class="exp-lead">
+            <h2 class="section-title" data-reveal>
+              I turn models into<br /><span class="accent-text">fast, dependable endpoints.</span>
+            </h2>
+            <div class="stats" data-reveal style="--reveal-delay: 140ms">
+              {stats.map((s) => (
+                <div class="stat">
+                  <span
+                    class="stat-num"
+                    data-count={s.value}
+                    data-decimals={s.decimals}
+                    data-prefix={s.prefix}
+                    data-suffix={s.suffix}
+                  >{s.prefix}0{s.suffix}</span>
+                  <span class="stat-label">{s.label}</span>
+                </div>
+              ))}
             </div>
-          </a>
-        ))}
-      </div>
-      <a class="all-repos" href="https://github.com/Nightshade14?tab=repositories" target="_blank" rel="noopener" data-reveal>
-        All repositories on GitHub <span aria-hidden="true">↗</span>
-      </a>
-    </section>
-
-    <!-- ================= RESEARCH ================= -->
-    <section id="research" class="section shell">
-      <p class="eyebrow" data-reveal>research</p>
-      <div class="paper" data-reveal>
-        <span class="paper-badge">Published · peer-reviewed</span>
-        <h3 class="paper-title">
-          Benchmarking Fine-Tuned Transformers, LLMs and LSTM Networks for Automated Essay Scoring
-        </h3>
-        <p class="paper-desc">
-          A comparative study of how transformer fine-tuning, large language models, and recurrent
-          baselines trade off accuracy against the cost of scoring at scale — with the fine-tuned
-          approach exceeding prior benchmarks by 5.7%.
-        </p>
-        <div class="paper-links">
-          <a class="paper-cta" href={PAPER_URL} target="_blank" rel="noopener">
-            Read on ResearchGate <span aria-hidden="true">↗</span>
-          </a>
-          <a class="paper-pdf" href={PAPER_PDF} target="_blank" rel="noopener">PDF</a>
+          </div>
+          <div class="exp-body" data-reveal style="--reveal-delay: 90ms">
+            <p>
+              I'm an AI Systems Engineer and MS Computer Science student at NYU, focused on the part of
+              machine learning that decides whether it's actually useful: <strong>how it's served.</strong>{' '}
+              My work sits where software engineering, systems, and ML meet — making inference fast, cheap,
+              and reliable at scale.
+            </p>
+            <ul class="exp-list">
+              {highlights.map((h) => <li>{h}</li>)}
+            </ul>
+            <div class="creds">
+              {creds.map((c) => <span class="cred">{c}</span>)}
+            </div>
+          </div>
         </div>
-      </div>
-    </section>
+      </section>
 
-    <!-- ================= CONTACT / FOOTER ================= -->
-    <footer id="contact" class="footer">
-      <div class="shell">
-        <p class="eyebrow" data-reveal>connect</p>
-        <h2 class="footer-title" data-reveal>Let's make something respond faster.</h2>
-        <div class="link-grid" data-reveal style="--reveal-delay: 90ms">
-          {links.map((l) => (
-            <a class="link-row" href={l.url} target="_blank" rel="noopener">
-              <span class="link-label">{l.label}</span>
-              <span class="link-handle">{l.handle}</span>
+      <!-- ================= WORK ================= -->
+      <section id="work" class="section shell">
+        <p class="eyebrow" data-reveal>work</p>
+        <h2 class="section-title" data-reveal>Selected projects</h2>
+        <div class="work-grid">
+          {projects.map((p, i) => (
+            <a class="work-card" data-tilt href={p.url} target="_blank" rel="noopener" data-reveal style={`--reveal-delay: ${i * 55}ms`}>
+              <span class="work-glare" aria-hidden="true"></span>
+              <div class="work-inner">
+                <div class="work-top">
+                  <span class="work-tag">{p.tag}</span>
+                  <span class="work-open" aria-hidden="true">→</span>
+                </div>
+                <h3 class="work-name">{p.name}</h3>
+                <p class="work-desc">{p.desc}</p>
+                <div class="work-meta">
+                  <span class="work-lang"><span class="lang-dot"></span>{p.lang}</span>
+                  {p.star > 0 && <span class="work-star">★ {p.star}</span>}
+                </div>
+              </div>
             </a>
           ))}
         </div>
-        <div class="footer-foot">
-          <span class="foot-brand"><span class="brand-dot"></span>Satyam Chatrola</span>
-          <span class="foot-note">Built with Astro · hosted on GitHub Pages · © 2026</span>
+        <a class="all-repos" href="https://github.com/Nightshade14?tab=repositories" target="_blank" rel="noopener" data-reveal>
+          All repositories on GitHub <span aria-hidden="true">↗</span>
+        </a>
+      </section>
+
+      <!-- ================= RESEARCH ================= -->
+      <section id="research" class="section shell">
+        <p class="eyebrow" data-reveal>research</p>
+        <div class="paper" data-reveal>
+          <span class="paper-badge">Published · peer-reviewed</span>
+          <h3 class="paper-title">
+            Benchmarking Fine-Tuned Transformers, LLMs and LSTM Networks for Automated Essay Scoring
+          </h3>
+          <p class="paper-desc">
+            A comparative study of how transformer fine-tuning, large language models, and recurrent
+            baselines trade off accuracy against the cost of scoring at scale — with the fine-tuned
+            approach exceeding prior benchmarks by 5.7%.
+          </p>
+          <div class="paper-links">
+            <a class="paper-cta" href={PAPER_URL} target="_blank" rel="noopener">
+              Read on ResearchGate <span aria-hidden="true">↗</span>
+            </a>
+            <a class="paper-pdf" href={PAPER_PDF} target="_blank" rel="noopener">PDF</a>
+          </div>
         </div>
-      </div>
-    </footer>
+      </section>
+
+      <!-- ================= CONTACT / FOOTER ================= -->
+      <footer id="contact" class="footer">
+        <div class="shell">
+          <p class="eyebrow" data-reveal>connect</p>
+          <h2 class="footer-title" data-reveal>Let's make something respond faster.</h2>
+          <div class="link-grid" data-reveal style="--reveal-delay: 90ms">
+            {links.map((l) => (
+              <a class="link-row" href={l.url} target="_blank" rel="noopener">
+                <span class="link-label">{l.label}</span>
+                <span class="link-handle">{l.handle}</span>
+              </a>
+            ))}
+          </div>
+          <div class="footer-foot">
+            <span class="foot-brand"><span class="brand-dot"></span>Satyam Chatrola</span>
+            <span class="foot-note">Built with Astro · hosted on GitHub Pages · © 2026</span>
+          </div>
+        </div>
+      </footer>
+    </div>
   </main>
 
   <script define:vars={{ RESPONSES }}>
     const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    // Pointer-driven effects only make sense with a precise pointer (skip touch).
     const finePointer = window.matchMedia('(pointer: fine)').matches;
     const interactive = finePointer && !prefersReduced;
 
-    /* ---- Signature: stream the hero "response" token by token, re-runnable via "resample". ---- */
+    /* ---- Boot progress: scroll 0 → ~1 viewport drives the engine crossfade + hero fade. ---- */
+    const BOOT_SPAN = 1.05; // viewport-heights of scroll to finish "booting"
+    const root = document.documentElement;
+    window.__bootP = 0;
+    let bootTick = false;
+    function setBoot() {
+      bootTick = false;
+      const p = Math.min(Math.max(window.scrollY / (window.innerHeight * BOOT_SPAN), 0), 1);
+      window.__bootP = p;
+      root.style.setProperty('--boot', p.toFixed(4));
+    }
+    const requestBoot = () => { if (!bootTick) { bootTick = true; requestAnimationFrame(setBoot); } };
+    window.addEventListener('scroll', requestBoot, { passive: true });
+    window.addEventListener('resize', requestBoot, { passive: true });
+    setBoot();
+
+    /* ---- Hero readout: the engine "comes online" when the 3D engine is ready. ---- */
+    const roTps = document.getElementById('ro-tps');
+    const roTtft = document.getElementById('ro-ttft');
+    const roUtil = document.getElementById('ro-util');
+    function spinUp() {
+      if (prefersReduced) {
+        if (roTps) roTps.textContent = '128';
+        if (roTtft) roTtft.textContent = '41ms';
+        if (roUtil) roUtil.textContent = '94';
+        return;
+      }
+      const dur = 1400, start = performance.now();
+      const tick = (now) => {
+        const t = Math.min((now - start) / dur, 1);
+        const e = 1 - Math.pow(1 - t, 3);
+        if (roTps) roTps.textContent = String(Math.round(e * 128));
+        if (roUtil) roUtil.textContent = String(Math.round(e * 94));
+        if (roTtft) roTtft.textContent = t < 0.55 ? '—' : '41ms';
+        if (t < 1) requestAnimationFrame(tick);
+      };
+      requestAnimationFrame(tick);
+    }
+
+    // Phase the hero text in only AFTER the engine has rendered: a short beat
+    // once it reports ready (so the GPU has visibly materialized first), or
+    // immediately if it failed / on a safety timeout — the hero never sticks.
+    const stageInner = document.querySelector('.stage-inner');
+    let heroLit = false, revealScheduled = false;
+    function litHero() {
+      if (heroLit) return;
+      heroLit = true;
+      if (stageInner) stageInner.classList.add('hero-lit');
+      spinUp();
+    }
+    function scheduleHero(delay) {
+      if (revealScheduled) return;
+      revealScheduled = true;
+      setTimeout(litHero, prefersReduced ? 0 : delay);
+    }
+    if (prefersReduced) {
+      litHero(); // no phase-in for reduced motion — show it right away
+    } else {
+      // a short beat after the engine reports ready lets the GPU start
+      // materializing before the text writes over it.
+      window.addEventListener('engine:ready', () => scheduleHero(350));
+      setTimeout(() => scheduleHero(0), 3400); // safety: never leave the hero blank
+    }
+
+    /* ---- Signature: stream the "response" token by token, re-runnable via "resample". ---- */
     const el = document.getElementById('decode');
     const cursor = document.getElementById('cursor');
     const tokEl = document.getElementById('tokcount');
@@ -366,32 +450,26 @@ const links = [
       setTimeout(step, lead);
     }
 
-    runDecode(RESPONSES[0], 520);
+    // Kick off the decode when the response section first scrolls into view.
+    const respSection = document.getElementById('response');
+    let decodeStarted = false;
+    const startDecode = () => { if (!decodeStarted) { decodeStarted = true; runDecode(RESPONSES[0], 260); } };
+    if (respSection && 'IntersectionObserver' in window && !prefersReduced) {
+      const rio = new IntersectionObserver((entries) => {
+        if (entries.some((e) => e.isIntersecting)) { rio.disconnect(); startDecode(); }
+      }, { threshold: 0.35 });
+      rio.observe(respSection);
+    } else {
+      startDecode();
+    }
     if (regen) {
       regen.addEventListener('click', () => {
+        decodeStarted = true;
         respIndex = (respIndex + 1) % RESPONSES.length;
         regen.classList.add('is-spinning');
         setTimeout(() => regen.classList.remove('is-spinning'), 520);
         runDecode(RESPONSES[respIndex], 120);
       });
-    }
-
-    /* ---- Cursor spotlight: a soft cyan light that trails the pointer. ---- */
-    const spotlight = document.querySelector('.spotlight');
-    if (spotlight && interactive) {
-      let sx = window.innerWidth / 2, sy = window.innerHeight * 0.28;
-      let tx = sx, ty = sy, raf = 0;
-      const loop = () => {
-        sx += (tx - sx) * 0.12;
-        sy += (ty - sy) * 0.12;
-        spotlight.style.transform = `translate(${sx}px, ${sy}px) translate(-50%, -50%)`;
-        raf = (Math.abs(tx - sx) > 0.4 || Math.abs(ty - sy) > 0.4) ? requestAnimationFrame(loop) : 0;
-      };
-      window.addEventListener('pointermove', (e) => {
-        tx = e.clientX; ty = e.clientY;
-        if (!raf) raf = requestAnimationFrame(loop);
-      }, { passive: true });
-      spotlight.classList.add('on');
     }
 
     /* ---- Magnetic buttons: gently pull toward the pointer, spring back on leave. ---- */
@@ -466,7 +544,7 @@ const links = [
       top: 0;
       z-index: 50;
       backdrop-filter: blur(12px);
-      background: color-mix(in oklab, var(--bg) 72%, transparent);
+      background: color-mix(in oklab, var(--void) 55%, transparent);
       border-bottom: 1px solid var(--line);
     }
     .nav-inner {
@@ -527,6 +605,7 @@ const links = [
       border: 1px solid var(--line-2);
       border-radius: 999px;
       color: var(--text);
+      background: color-mix(in oklab, var(--void) 40%, transparent);
       transition: border-color 0.2s, background 0.2s, color 0.2s, transform 0.2s;
       white-space: nowrap;
     }
@@ -544,52 +623,157 @@ const links = [
       box-shadow: 0 0 30px var(--accent-glow);
     }
 
-    /* ===================== HERO ===================== */
-    .hero {
-      padding-top: clamp(3.5rem, 8vh, 7rem);
-      padding-bottom: clamp(3.5rem, 8vh, 7rem);
-      display: grid;
-      grid-template-columns: 1.02fr 0.98fr;
+    /* ===================== HERO (overlay on the fixed engine) ===================== */
+    .stage {
+      position: relative;
+      z-index: 1;
+      height: 100svh;
+      min-height: 34rem;
+      display: flex;
+      align-items: flex-end;
+      /* leave clear room below the copy for the scroll cue */
+      padding-bottom: clamp(5rem, 13vh, 8rem);
+      padding-top: 4.5rem;
+      overflow: hidden;
+    }
+    /* darken the lower third so hero copy stays legible over the GPU */
+    .stage::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      z-index: -1;
+      pointer-events: none;
+      background: linear-gradient(180deg, transparent 30%, color-mix(in oklab, var(--void) 82%, transparent) 100%);
+    }
+    /* the whole hero dissolves upward as the site boots */
+    .stage-inner {
+      opacity: calc(1 - var(--boot) * 1.7);
+      transform: translateY(calc(var(--boot) * -42px));
+      will-change: opacity, transform;
+    }
+    /* hero text phases in only AFTER the engine renders — JS adds .hero-lit,
+       then each item eases up on its own staggered delay */
+    [data-hero] { opacity: 0; transform: translateY(18px); }
+    .hero-lit [data-hero] {
+      animation: hero-in 0.95s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+      animation-delay: var(--reveal-delay, 0ms);
+    }
+    @keyframes hero-in { to { opacity: 1; transform: none; } }
+    @media (prefers-reduced-motion: reduce) {
+      [data-hero] { opacity: 1; transform: none; animation: none; }
+    }
+
+    .eyebrow-live::before { animation: gpu-pulse 1.6s ease-in-out infinite; }
+    @keyframes gpu-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.32; } }
+    @media (prefers-reduced-motion: reduce) { .eyebrow-live::before { animation: none; } }
+
+    .hero-name {
+      font-size: var(--step-4);
+      font-weight: 700;
+      letter-spacing: -0.04em;
+      line-height: 0.9;
+      margin: 1.3rem 0 1.1rem;
+      text-wrap: balance;
+    }
+    .hero-role {
+      font-family: var(--font-mono);
+      font-size: clamp(0.95rem, 0.85rem + 0.7vw, 1.35rem);
+      color: var(--text-dim);
+      letter-spacing: 0.01em;
+      margin-bottom: 1.5rem;
+    }
+    .role-sep { color: var(--accent); margin: 0 0.15em; }
+
+    .hero-readout {
+      font-family: var(--font-mono);
+      font-size: var(--step--1);
+      color: var(--text-faint);
+      letter-spacing: 0.03em;
+      display: inline-flex;
       align-items: center;
-      gap: clamp(1.5rem, 4vw, 3.5rem);
+      flex-wrap: wrap;
+      gap: 0.1rem 0.55rem;
+      margin-bottom: 1.9rem;
     }
-    .hero-visual { position: relative; min-width: 0; }
-    @media (max-width: 900px) {
-      .hero {
-        grid-template-columns: 1fr;
-        gap: 1rem;
-      }
-      .hero-visual { order: -1; } /* show the GPU above the copy on narrow screens */
+    .hero-readout span[id] { color: var(--accent); font-variant-numeric: tabular-nums; }
+    .ro-sep { color: var(--text-faint) !important; opacity: 0.5; }
+    .ro-dot {
+      width: 6px; height: 6px; border-radius: 50%;
+      background: var(--accent); box-shadow: 0 0 9px var(--accent-glow);
+      margin-right: 0.5em;
+      animation: gpu-pulse 1.6s ease-in-out infinite;
     }
+    @media (prefers-reduced-motion: reduce) { .ro-dot { animation: none; } }
+    .hero-cta { display: flex; gap: 0.8rem; flex-wrap: wrap; }
+
+    /* scroll cue pinned to the bottom of the hero */
+    .scroll-cue {
+      position: absolute;
+      left: 50%;
+      bottom: clamp(1.1rem, 2.6vh, 1.9rem);
+      transform: translateX(-50%);
+      display: inline-flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.5rem;
+      font-family: var(--font-mono);
+      font-size: var(--step--1);
+      letter-spacing: 0.12em;
+      color: var(--text-faint);
+      opacity: calc(1 - var(--boot) * 4);
+      transition: color 0.2s;
+    }
+    .scroll-cue:hover { color: var(--accent); }
+    .cue-arrow { animation: cue-bob 1.8s ease-in-out infinite; }
+    @keyframes cue-bob { 0%, 100% { transform: translateY(0); opacity: 0.6; } 50% { transform: translateY(5px); opacity: 1; } }
+    @media (prefers-reduced-motion: reduce) { .cue-arrow { animation: none; } }
+
+    /* ===================== DECK (content booted in over the engine) ===================== */
+    .deck {
+      position: relative;
+      z-index: 1;
+      /* mostly-opaque scrim: text stays crisp, the engine lingers faintly behind */
+      background: color-mix(in oklab, var(--void) 88%, transparent);
+      border-top: 1px solid var(--line);
+    }
+
+    /* ===================== SECTIONS ===================== */
+    .section {
+      padding-block: clamp(3.5rem, 9vh, 7rem);
+      border-top: 1px solid var(--line);
+    }
+    .deck > .section:first-of-type { border-top: none; }
+    .section-title {
+      font-size: var(--step-2);
+      margin-top: 0.8rem;
+      margin-bottom: 2.6rem;
+      max-width: 20ch;
+    }
+    .accent-text { font-weight: inherit; color: var(--accent); }
+
+    /* ---- response / decode ---- */
     .prompt {
       font-family: var(--font-mono);
       font-size: var(--step--1);
       color: var(--text-faint);
       letter-spacing: 0.05em;
-      margin-bottom: 1.4rem;
+      margin-top: 0.9rem;
     }
     .prompt-caret { color: var(--accent); margin-right: 0.4em; }
-    .hero-name {
-      font-size: var(--step-4);
-      font-weight: 700;
-      letter-spacing: -0.035em;
-      line-height: 0.92;
-      margin-bottom: 1.6rem;
-    }
-    .hero-response {
+    .decode-line {
       font-family: var(--font-mono);
-      font-size: clamp(1rem, 0.9rem + 0.9vw, 1.4rem);
-      line-height: 1.55;
-      color: var(--text-dim);
-      max-width: min(42ch, 100%);
+      font-size: clamp(1.05rem, 0.95rem + 1.1vw, 1.7rem);
+      line-height: 1.5;
+      color: var(--text);
+      max-width: 46ch;
       overflow-wrap: break-word;
-      min-height: 6em; /* reserve space so streaming doesn't reflow the page */
-      margin-bottom: 1.6rem;
+      min-height: 4.6em;
+      margin: 1.1rem 0 1.4rem;
     }
-    .hero-response strong, .accent-text { color: var(--accent); font-weight: inherit; }
+    .decode-line strong { color: var(--accent); font-weight: inherit; }
     .cursor {
       display: inline-block;
-      width: 0.6ch;
+      width: 0.55ch;
       height: 1.05em;
       transform: translateY(0.18em);
       margin-left: 0.08em;
@@ -599,7 +783,7 @@ const links = [
     .cursor.is-idle { animation-duration: 1.4s; opacity: 0.7; }
     @keyframes blink { 0%, 50% { opacity: 1; } 50.01%, 100% { opacity: 0; } }
     @media (prefers-reduced-motion: reduce) { .cursor { animation: none; } }
-
+    .decode-meta { display: flex; align-items: center; gap: 0.9rem 1.4rem; flex-wrap: wrap; }
     .telemetry {
       display: flex;
       align-items: center;
@@ -607,17 +791,11 @@ const links = [
       font-family: var(--font-mono);
       font-size: var(--step--1);
       color: var(--text-faint);
-      margin-bottom: 2.4rem;
       flex-wrap: wrap;
     }
     .tel-sep { opacity: 0.5; }
     .tel-item span { color: var(--accent); }
-    .tel-bar {
-      width: 88px; height: 3px;
-      background: var(--line-2);
-      border-radius: 2px;
-      overflow: hidden;
-    }
+    .tel-bar { width: 88px; height: 3px; background: var(--line-2); border-radius: 2px; overflow: hidden; }
     .tel-fill {
       display: block; height: 100%; width: 0%;
       background: var(--accent);
@@ -626,20 +804,31 @@ const links = [
     }
     .tel-status { color: var(--text-faint); }
     .tel-status.is-done { color: var(--accent); }
-    .hero-cta { display: flex; gap: 0.8rem; flex-wrap: wrap; }
-
-    /* ===================== SECTIONS ===================== */
-    .section {
-      padding-block: clamp(3.5rem, 9vh, 7rem);
-      border-top: 1px solid var(--line);
+    .regen {
+      font-family: var(--font-mono);
+      font-size: var(--step--1);
+      color: var(--text-faint);
+      background: transparent;
+      border: 1px solid var(--line-2);
+      border-radius: 999px;
+      padding: 0.34em 0.85em;
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.45em;
+      transition: color 0.2s, border-color 0.2s, background 0.2s, transform 0.2s;
     }
-    .section-title {
-      font-size: var(--step-2);
-      margin-top: 0.8rem;
-      margin-bottom: 2.6rem;
-      max-width: 20ch;
+    .regen:hover {
+      color: var(--accent);
+      border-color: var(--accent-line);
+      background: var(--accent-dim);
+      transform: translateY(-1px);
     }
-    .accent-text { font-weight: inherit; }
+    .regen:active { transform: translateY(0) scale(0.97); }
+    .regen-ico { display: inline-block; transition: transform 0.3s; }
+    .regen:hover .regen-ico { transform: rotate(-90deg); }
+    .regen.is-spinning .regen-ico { animation: spin 0.52s cubic-bezier(0.5, 0, 0.2, 1); }
+    @keyframes spin { to { transform: rotate(360deg); } }
 
     /* ---- focus grid ---- */
     .focus-grid {
@@ -652,11 +841,11 @@ const links = [
       overflow: hidden;
     }
     .focus-card {
-      background: var(--bg);
+      background: color-mix(in oklab, var(--panel) 80%, transparent);
       padding: clamp(1.4rem, 3vw, 2.2rem);
       transition: background 0.3s;
     }
-    .focus-card:hover { background: var(--bg-1); }
+    .focus-card:hover { background: var(--panel-2); }
     .focus-k {
       font-family: var(--font-mono);
       font-size: var(--step--1);
@@ -669,7 +858,7 @@ const links = [
       .focus-grid { grid-template-columns: 1fr; }
     }
 
-    /* ---- experience ---- */
+    /* ---- experience / signal ---- */
     .exp { display: grid; grid-template-columns: 1.1fr 1fr; gap: clamp(1.5rem, 5vw, 4rem); }
     .exp .section-title { margin-bottom: 0; }
     .exp-body p { color: var(--text-dim); margin-bottom: 1.6rem; }
@@ -710,17 +899,31 @@ const links = [
     .work-card {
       display: flex;
       flex-direction: column;
-      background: var(--bg-1);
+      background: color-mix(in oklab, var(--panel) 82%, transparent);
       border: 1px solid var(--line);
       border-radius: var(--radius);
       padding: 1.4rem;
       min-height: 210px;
       transition: border-color 0.28s, transform 0.28s, background 0.28s;
+      position: relative;
+      overflow: hidden;
+      transform-style: preserve-3d;
+      will-change: transform;
     }
     .work-card:hover {
       border-color: var(--accent-line);
       transform: translateY(-3px);
-      background: var(--bg-2);
+      background: var(--panel-2);
+    }
+    .work-inner { position: relative; z-index: 1; display: flex; flex-direction: column; flex: 1; }
+    .work-glare {
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.3s ease;
+      z-index: 2;
     }
     .work-top { display: flex; justify-content: space-between; align-items: center; }
     .work-tag {
@@ -776,7 +979,7 @@ const links = [
     }
     .all-repos:hover { color: var(--accent); border-color: var(--accent-line); }
 
-    /* ---- research paper (single featured card, left accent rule) ---- */
+    /* ---- research paper ---- */
     .paper {
       position: relative;
       border: 1px solid var(--line);
@@ -785,7 +988,7 @@ const links = [
       padding: clamp(1.6rem, 4vw, 2.8rem);
       background:
         radial-gradient(120% 140% at 0% 0%, rgba(34,211,238,0.07), transparent 55%),
-        var(--bg-1);
+        color-mix(in oklab, var(--panel) 82%, transparent);
       transition: border-color 0.3s, transform 0.3s, background 0.3s;
     }
     .paper:hover {
@@ -832,7 +1035,7 @@ const links = [
       padding-block: clamp(3.5rem, 9vh, 7rem) 2.5rem;
       background:
         radial-gradient(90% 120% at 100% 100%, rgba(34,211,238,0.06), transparent 60%),
-        var(--bg);
+        transparent;
     }
     .footer-title {
       font-size: var(--step-2);
@@ -883,26 +1086,7 @@ const links = [
     }
     .foot-brand { display: inline-flex; align-items: center; gap: 0.55em; color: var(--text-dim); }
 
-    /* ===================== INTERACTIVE LAYER ===================== */
-    /* cursor spotlight — soft cyan light trailing the pointer */
-    .spotlight {
-      position: fixed;
-      top: 0; left: 0;
-      width: 620px; height: 620px;
-      border-radius: 50%;
-      pointer-events: none;
-      z-index: 0;
-      opacity: 0;
-      background: radial-gradient(circle, rgba(34, 211, 238, 0.09), transparent 62%);
-      filter: blur(6px);
-      transition: opacity 0.6s ease;
-      will-change: transform;
-    }
-    .spotlight.on { opacity: 1; }
-    @media (prefers-reduced-motion: reduce) { .spotlight { display: none; } }
-    main { position: relative; z-index: 1; }
-
-    /* brand dot "boop" on hover */
+    /* ===================== MICRO-INTERACTIONS ===================== */
     .brand:hover .brand-dot,
     .foot-brand:hover .brand-dot {
       animation: boop 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
@@ -914,42 +1098,8 @@ const links = [
     }
     @media (prefers-reduced-motion: reduce) {
       .brand:hover .brand-dot, .foot-brand:hover .brand-dot { animation: none; }
+      .stage-inner { opacity: calc(1 - var(--boot) * 1.1); }
     }
-
-    /* hero meta row + resample control */
-    .hero-meta {
-      display: flex;
-      align-items: center;
-      gap: 0.9rem 1.4rem;
-      flex-wrap: wrap;
-      margin-bottom: 2.4rem;
-    }
-    .telemetry { margin-bottom: 0; }
-    .regen {
-      font-family: var(--font-mono);
-      font-size: var(--step--1);
-      color: var(--text-faint);
-      background: transparent;
-      border: 1px solid var(--line-2);
-      border-radius: 999px;
-      padding: 0.34em 0.85em;
-      cursor: pointer;
-      display: inline-flex;
-      align-items: center;
-      gap: 0.45em;
-      transition: color 0.2s, border-color 0.2s, background 0.2s, transform 0.2s;
-    }
-    .regen:hover {
-      color: var(--accent);
-      border-color: var(--accent-line);
-      background: var(--accent-dim);
-      transform: translateY(-1px);
-    }
-    .regen:active { transform: translateY(0) scale(0.97); }
-    .regen-ico { display: inline-block; transition: transform 0.3s; }
-    .regen:hover .regen-ico { transform: rotate(-90deg); }
-    .regen.is-spinning .regen-ico { animation: spin 0.52s cubic-bezier(0.5, 0, 0.2, 1); }
-    @keyframes spin { to { transform: rotate(360deg); } }
 
     /* count-up stats */
     .stats {
@@ -971,23 +1121,5 @@ const links = [
     }
     .stat-label { font-family: var(--font-mono); font-size: var(--step--1); color: var(--text-faint); }
     @media (max-width: 800px) { .stats { margin-top: 2rem; max-width: none; } }
-
-    /* project card tilt + glare */
-    .work-card {
-      position: relative;
-      overflow: hidden;
-      transform-style: preserve-3d;
-      will-change: transform;
-    }
-    .work-inner { position: relative; z-index: 1; display: flex; flex-direction: column; flex: 1; }
-    .work-glare {
-      position: absolute;
-      inset: 0;
-      border-radius: inherit;
-      opacity: 0;
-      pointer-events: none;
-      transition: opacity 0.3s ease;
-      z-index: 2;
-    }
   </style>
 </Base>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,30 +1,39 @@
 /* ============================================================
-   Design tokens — dark, cinematic, one electric-cyan accent.
-   Personality lives in the type system + the decode signature;
-   everything else stays disciplined and monochrome.
+   Design tokens — "compute night": a blue-forward dark palette
+   with one electric-cyan star. The GPU engine (a fixed WebGL
+   backdrop) owns the ambient light; the type system + the boot
+   sequence + the decode signature carry the personality.
+   Everything else stays disciplined.
    ============================================================ */
 :root {
-  /* surfaces — cool near-black, not pure #000 (softer, more filmic) */
-  --bg:          #08090b;
-  --bg-1:        #0d0f13;
-  --bg-2:        #14171c;
-  --line:        rgba(255, 255, 255, 0.08);
-  --line-2:      rgba(255, 255, 255, 0.14);
+  /* surfaces — deep blue-black, richer than neutral near-black */
+  --void:   #05070d;
+  --panel:  #0a0e18;
+  --panel-2:#111826;
 
-  /* ink */
-  --text:        #e9ecf0;
-  --text-dim:    #9aa4af;
-  --text-faint:  #5c656f;
+  /* legacy aliases kept so component CSS reads naturally */
+  --bg:     var(--void);
+  --bg-1:   var(--panel);
+  --bg-2:   var(--panel-2);
 
-  /* the single accent — electric cyan, used sparingly */
+  --line:   rgba(150, 180, 220, 0.09);
+  --line-2: rgba(150, 180, 220, 0.17);
+
+  /* ink — cooled slightly toward blue */
+  --text:       #eaf0f6;
+  --text-dim:   #9fb0c3;
+  --text-faint: #5b6c81;
+
+  /* the electric-cyan system — used sparingly, the single star */
   --accent:      #22d3ee;
-  --accent-hi:   #7ce9f7;
+  --accent-hi:   #7ef9ff;          /* "ion" hot highlight */
+  --deep:        #2f6bff;          /* depth-only, lives in gradients */
   --accent-dim:  rgba(34, 211, 238, 0.10);
   --accent-line: rgba(34, 211, 238, 0.38);
-  --accent-glow: rgba(34, 211, 238, 0.28);
+  --accent-glow: rgba(34, 211, 238, 0.30);
 
-  /* type */
-  --font-display: 'Space Grotesk Variable', ui-sans-serif, system-ui, sans-serif;
+  /* type — Bricolage Grotesque (display personality) + Geist + mono */
+  --font-display: 'Bricolage Grotesque Variable', ui-sans-serif, system-ui, sans-serif;
   --font-body:    'Geist Variable', ui-sans-serif, system-ui, sans-serif;
   --font-mono:    'Geist Mono Variable', ui-monospace, 'SF Mono', monospace;
 
@@ -41,6 +50,9 @@
   --measure: 68ch;
   --radius: 14px;
   --shell: 1180px;
+
+  /* boot progress (0 = full-screen engine, 1 = site booted) — set by JS */
+  --boot: 0;
 }
 
 /* ---------- reset ---------- */
@@ -52,7 +64,7 @@ html { -webkit-text-size-adjust: 100%; scroll-behavior: smooth; }
 }
 
 body {
-  background: var(--bg);
+  background: var(--void);
   color: var(--text);
   font-family: var(--font-body);
   font-size: var(--step-0);
@@ -61,11 +73,10 @@ body {
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
   overflow-x: hidden;
-  /* faint filmic vignette + a single cyan light source, top-left */
+  /* faint base glow shown before/behind the WebGL engine (fallback too) */
   background-image:
-    radial-gradient(120% 90% at 8% -10%, rgba(34, 211, 238, 0.06), transparent 55%),
-    radial-gradient(80% 60% at 100% 0%, rgba(255, 255, 255, 0.03), transparent 50%);
-  background-attachment: fixed;
+    radial-gradient(120% 80% at 50% -10%, rgba(34, 211, 238, 0.05), transparent 55%),
+    radial-gradient(90% 60% at 100% 0%, rgba(47, 107, 255, 0.05), transparent 55%);
 }
 
 img, svg { display: block; max-width: 100%; }
@@ -94,7 +105,7 @@ h1, h2, h3 {
   padding-inline: var(--gutter);
 }
 
-/* a mono eyebrow used to label every section — the "endpoint" vernacular */
+/* mono eyebrow — the "serving vernacular" label on every section */
 .eyebrow {
   font-family: var(--font-mono);
   font-size: var(--step--1);


### PR DESCRIPTION
Make the GPU the central element the whole page boots on: a fixed full-viewport WebGL "engine" that fills the screen on load, dollies back and crossfades to a faint always-running backdrop as you scroll.

- Cold start reads as powering-on: a breathing cyan core while three.js and the model load, then the GPU materializes (slow opacity fade + eased scale-up + gentle bloom surge), then the hero text phases in.
- Hero text gated on an engine:ready signal (with failure/timeout fallbacks) so it appears just after the GPU, never on a blank screen.
- Palette deepened to a blue-forward "compute night"; display type swapped Space Grotesk -> Bricolage Grotesque (Geist / Geist Mono kept).
- Restructured page: hero overlay + decode "response" section + focus, signal, work, research, contact over a scrim that lets the engine glow through faintly.
- prefers-reduced-motion and no-JS paths kept fully legible.